### PR TITLE
Add global web speech types for voice features

### DIFF
--- a/Library/Mobile Documents/com~apple~CloudDocs/Projects/Journal.heijo/tsconfig.json
+++ b/Library/Mobile Documents/com~apple~CloudDocs/Projects/Journal.heijo/tsconfig.json
@@ -23,7 +23,7 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "types/**/*.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }
 

--- a/Library/Mobile Documents/com~apple~CloudDocs/Projects/Journal.heijo/types/web-speech.d.ts
+++ b/Library/Mobile Documents/com~apple~CloudDocs/Projects/Journal.heijo/types/web-speech.d.ts
@@ -1,0 +1,66 @@
+declare global {
+  interface SpeechRecognitionAlternative {
+    transcript: string;
+    confidence: number;
+  }
+
+  interface SpeechRecognitionResult {
+    readonly length: number;
+    readonly isFinal: boolean;
+    [index: number]: SpeechRecognitionAlternative;
+    item(index: number): SpeechRecognitionAlternative;
+  }
+
+  interface SpeechRecognitionResultList {
+    readonly length: number;
+    [index: number]: SpeechRecognitionResult;
+    item(index: number): SpeechRecognitionResult;
+  }
+
+  type SpeechRecognitionEvent = Event & {
+    readonly resultIndex: number;
+    readonly results: SpeechRecognitionResultList;
+  };
+
+  interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: string;
+    readonly message: string;
+  }
+
+  interface SpeechRecognition extends EventTarget {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    maxAlternatives: number;
+    onaudioend: ((event: Event) => void) | null;
+    onaudiostart: ((event: Event) => void) | null;
+    onend: ((event: Event) => void) | null;
+    onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+    onresult: ((event: SpeechRecognitionEvent) => void) | null;
+    onsoundend: ((event: Event) => void) | null;
+    onsoundstart: ((event: Event) => void) | null;
+    onspeechend: ((event: Event) => void) | null;
+    onspeechstart: ((event: Event) => void) | null;
+    onstart: ((event: Event) => void) | null;
+    abort(): void;
+    start(): void;
+    stop(): void;
+  }
+
+  var SpeechRecognition: {
+    prototype: SpeechRecognition;
+    new (): SpeechRecognition;
+  };
+
+  var webkitSpeechRecognition: {
+    prototype: SpeechRecognition;
+    new (): SpeechRecognition;
+  };
+
+  interface Window {
+    SpeechRecognition: typeof SpeechRecognition;
+    webkitSpeechRecognition: typeof webkitSpeechRecognition;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a dedicated web speech type definition to expose SpeechRecognition and related events globally
- configure the TypeScript build to automatically include the new ambient declaration directory

## Testing
- npm run build *(fails: Next.js cannot download Inter font due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d68b938d4083249d87936b3d4074a4