### PR TITLE
Preserve local journal entries on logout

### DIFF
--- a/docs/QA_MATRIX.md
+++ b/docs/QA_MATRIX.md
@@ -41,6 +41,22 @@
 
 ---
 
+### 2b) Regression — Entries Persist After Logout & Remain Isolated Per Account
+**Steps:**
+1. Sign in with Account A and create a new entry.
+2. Sign out, refresh the page, and sign back into Account A.
+3. Confirm the entry renders immediately from `localStorage` (before any network calls).
+4. Sign out again, then sign in with Account B.
+5. Confirm Account B sees an empty journal history (or only their own entries).
+6. Inspect `localStorage` and note that Account A stored data in `heijo-journal-entries:<accountA-id>` while Account B stores data under `heijo-journal-entries:<accountB-id>`.
+
+**Expected:**
+- Account A's entry persists across sign-out/sign-in cycles because the scoped key is retained.
+- Account B does not see Account A's entries because the key names differ per `userId`.
+- Deleting journal data on logout is unnecessary; key scoping already prevents cross-account leakage.
+
+---
+
 ### 3) Voice Input — Web Speech API
 **Steps:**
 1. Grant mic permission.

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -108,14 +108,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!supabase) return;
     
     // Clear user-specific localStorage data on sign out
-    // This prevents data leakage when switching accounts
+    // Entries remain intentionally because the key is already scoped as
+    // `heijo-journal-entries:${userId}`, so there is no cross-account leakage
     try {
       const session = await supabase.auth.getSession();
       const userId = session.data.session?.user?.id;
       
       if (userId) {
-        // Clear user-scoped storage key
-        localStorage.removeItem(`heijo-journal-entries:${userId}`);
+        // Keep journal entries so they rehydrate on next login; scoped keys prevent leakage
         // Clear analytics data (if user-specific)
         localStorage.removeItem('heijo_analytics');
         // Clear notification preferences (if user-specific)


### PR DESCRIPTION
## Summary
- keep locally stored journal entries when signing out because the storage key is already scoped per user and cannot leak data across accounts
- clarify the sign-out comments to explain why entry data stays in localStorage while still cleaning analytics and notification preferences
- add a regression QA scenario documenting how to verify entries persist after logout and remain isolated per account via keyed storage

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b122075e08324afd564a54dc61e27)