### PR TITLE
Handle legacy anonymous guest entries in storage filter

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -102,9 +102,11 @@ class HybridStorage implements StorageBackend {
     
     // Filter local entries to only those belonging to current user (STRICT filtering)
     // Do NOT show entries without user_id to logged-in users (security: prevents cross-account leakage)
+    const isGuestEntry = (entry: JournalEntry) => !entry.user_id || entry.user_id === 'anonymous';
+
     const filteredLocalEntries = currentUserId
       ? localEntries.filter(entry => entry.user_id === currentUserId) // STRICT: Only exact matches
-      : localEntries.filter(entry => !entry.user_id); // Only anonymous entries if no userId
+      : localEntries.filter(isGuestEntry); // Treat legacy 'anonymous' entries as guest data
 
     // Try to get from Supabase only if user has premium and is authenticated
     try {

--- a/scripts/storage-filter-check.js
+++ b/scripts/storage-filter-check.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+/**
+ * Lightweight reproduction script for the strict local-entry filtering logic.
+ * Mirrors the guest vs. authenticated behavior in HybridStorage.getEntries.
+ */
+
+const entries = [
+  {
+    id: 'legacy-guest',
+    created_at: '2024-01-01T00:00:00.000Z',
+    content: 'Legacy guest entry saved before the fix',
+    source: 'text',
+    tags: [],
+    user_id: 'anonymous',
+    sync_status: 'local_only'
+  },
+  {
+    id: 'new-guest',
+    created_at: '2024-01-02T00:00:00.000Z',
+    content: 'New guest entry with no user id',
+    source: 'text',
+    tags: [],
+    user_id: undefined,
+    sync_status: 'local_only'
+  },
+  {
+    id: 'user-123-entry',
+    created_at: '2024-01-03T00:00:00.000Z',
+    content: 'Entry for user-123',
+    source: 'text',
+    tags: [],
+    user_id: 'user-123',
+    sync_status: 'synced'
+  },
+  {
+    id: 'user-456-entry',
+    created_at: '2024-01-04T00:00:00.000Z',
+    content: 'Entry for user-456',
+    source: 'text',
+    tags: [],
+    user_id: 'user-456',
+    sync_status: 'synced'
+  }
+];
+
+const filterEntries = (entries, currentUserId) => {
+  const isGuestEntry = (entry) => !entry.user_id || entry.user_id === 'anonymous';
+  return currentUserId
+    ? entries.filter(entry => entry.user_id === currentUserId)
+    : entries.filter(isGuestEntry);
+};
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+// Guest mode: should show both anonymous variants and nothing else
+const guestEntries = filterEntries(entries, undefined);
+assert(guestEntries.length === 2, 'Guest view should show both legacy and new guest entries');
+assert(guestEntries.some(entry => entry.id === 'legacy-guest'), 'Legacy guest entry missing (user_id="anonymous")');
+assert(guestEntries.some(entry => entry.id === 'new-guest'), 'New guest entry missing (no user_id)');
+
+// Authenticated mode: each user should only see their own data
+const user123Entries = filterEntries(entries, 'user-123');
+assert(user123Entries.length === 1 && user123Entries[0].id === 'user-123-entry', 'user-123 should only see their own entry');
+
+const user456Entries = filterEntries(entries, 'user-456');
+assert(user456Entries.length === 1 && user456Entries[0].id === 'user-456-entry', 'user-456 should only see their own entry');
+
+console.log('storage-filter-check: PASS – guest + authenticated filtering behave as expected');


### PR DESCRIPTION
## Summary
- treat legacy `user_id: "anonymous"` records as valid guest entries in `HybridStorage.getEntries`
- add a lightweight regression script that mirrors the strict filtering logic for guest and authenticated contexts

## Testing
- node scripts/storage-filter-check.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2f1f53748324800c06c8ed25ef47)